### PR TITLE
Removing code that doesn’t require since every unauthorized request must be ended.

### DIFF
--- a/app/redfish-handler.lua
+++ b/app/redfish-handler.lua
@@ -501,9 +501,9 @@ end
 --- Inherited modules can use this function to mark the session as unauthorized
 -- @param msg optional Sets an optional message
 function RedfishHandler:unauthorized(msg)
-	if finished then
+	--[[if finished then
 		return
-	end
+	end--]]
 
 	self:add_header("WWW-Authenticate", 'Basic realm="AMI_Redfish_Server"') --TODO make the realm unique
 	self:add_header("WWW-Authenticate", 'X-Auth-Token realm="AMI_Redfish_Server"') --TODO make the realm unique

--- a/app/redfish-handler.lua
+++ b/app/redfish-handler.lua
@@ -501,10 +501,7 @@ end
 --- Inherited modules can use this function to mark the session as unauthorized
 -- @param msg optional Sets an optional message
 function RedfishHandler:unauthorized(msg)
-	--[[if finished then
-		return
-	end--]]
-
+	
 	self:add_header("WWW-Authenticate", 'Basic realm="AMI_Redfish_Server"') --TODO make the realm unique
 	self:add_header("WWW-Authenticate", 'X-Auth-Token realm="AMI_Redfish_Server"') --TODO make the realm unique
 


### PR DESCRIPTION
Removing code that doesn’t require since every unauthorized request must be ended. 
Every unauthorized access to redfish API will return 401 unauthorized error message.